### PR TITLE
Updated for CraftCMS 5.x compatibility.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "la-haute-societe/craft-locale-selector",
     "description": "A Craft field type for selecting a site or a country",
     "type": "craft-plugin",
+    "version": "2.0.0",
     "keywords": [
         "craft",
         "cms",
@@ -20,7 +21,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^4.0.0",
+        "craftcms/cms": "^5.0.0",
         "rinvex/countries": "^7.3",
         "ext-intl": ">=1.0.0"
     },
@@ -39,5 +40,16 @@
         "developer": "La Haute Société",
         "developerUrl": "https://www.lahautesociete.com/",
         "class": "lhs\\craft\\localeSelectorField\\Plugin"
+    },
+    "config": {
+        "allow-plugins": {
+            "yiisoft/yii2-composer": true,
+            "craftcms/plugin-installer": true
+        }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true,
+    "require-dev": {
+        "craftcms/rector": "dev-main"
     }
 }

--- a/src/fields/LocalesSelectorField.php
+++ b/src/fields/LocalesSelectorField.php
@@ -102,7 +102,7 @@ class LocalesSelectorField extends Field implements PreviewableFieldInterface
      * @throws Exception
      * @see craft\base\Field
      */
-    public function getInputHtml($value, ElementInterface $element = null): string
+    public function getInputHtml(mixed $value, ?ElementInterface $element = null): string
     {
         /**
          * Retrieve useful data according to the type
@@ -169,7 +169,7 @@ class LocalesSelectorField extends Field implements PreviewableFieldInterface
      * @return array|mixed|CountryModel|void|null
      * @throws Exception
      */
-    public function normalizeValue(mixed $value, ElementInterface $element = null): mixed
+    public function normalizeValue(mixed $value, ?ElementInterface $element = null): mixed
     {
         if (is_null($value)) {
             return null;
@@ -200,7 +200,7 @@ class LocalesSelectorField extends Field implements PreviewableFieldInterface
      * @return string|null
      * @throws Exception
      */
-    public function serializeValue(mixed $value, ElementInterface $element = null): ?string
+    public function serializeValue(mixed $value, ?ElementInterface $element = null): ?string
     {
         return match ($this->datatype) {
             Plugin::DATATYPE_SITES => ($value instanceof Site) ? $value->handle : null,


### PR DESCRIPTION
Solves issue: https://github.com/la-haute-societe/craft-locale-picker/issues/1

Hello-

I use this plugin on one of my Craft sites that is being updated to Craft 5.x when I found out that this plugin is not updated for 5.x compatibility. I pulled the project and made the requisite changes to make it compatible. I added a `version` property to the `composer.json` file and specified version `2.0.0` - If you want to keep that scheme after merging this, then you should also deploy a new `2.0.0` tag to the repo so those that want to use the older version can still install 1.0 for Craft4 and those needing the new version for Craft5 can install the 2.0.0 version.

I have tested this against the updated craft site in the context for which I use the plugin and the code changes appear to be working correctly with Craft5.

Thanks!